### PR TITLE
Potential bug fix for a corner case in find() and additional method

### DIFF
--- a/@tree/find.m
+++ b/@tree/find.m
@@ -12,6 +12,7 @@ function I = find(obj, varargin)
 %   I = FIND(T,K,'last') returns at most the last K indices corresponding 
 %   to the nonzero entries of the tree T.
 %
+    obj.Node(cellfun(@isempty, obj.Node)) = {false};
     val = [ obj.Node{:} ] ;
     I = find(val, varargin{:});
 end

--- a/@tree/findbranchpoints.m
+++ b/@tree/findbranchpoints.m
@@ -1,0 +1,11 @@
+function indices = findbranchpoints(obj, varargin)
+%FIND   Find indices of nodes with more than one child.
+%   I = FINDBRANCHPOINTS(T) returns the linear indices corresponding to the
+%   nonzero entries of the tree T.
+
+      indices = find( ...
+          arrayfun(@(x) numel(obj.getchildren(x)), ...
+          obj.nodeorderiterator(), ...
+          'UniformOutput', true) > 1); 
+
+end


### PR DESCRIPTION
Hi! I have been using your great `@tree` class for a while and I recently committed a small fix and new commodity method. (Sorry that I put them in the same pull request). Please feel free to keep or reject as you wish.

## Bug fix in `@tree/find`

If a tree contains empty values in the `Node` property, the following will fail:

`find(myTree == value)`

since

`val = [ obj.Node{:} ] ;`

in `@tree/find` will cause the empty values to be dropped. The `val` array will be shorter than the original `obj.Node` array and the subsequent 

`I = find(val, varargin{:});`

call will return indices that are not pointing to the correct values in the tree.

## Commodity method `@tree/findbranchpoints`

A while ago I added a `@tree/findbranchpoints` method that comes in handy when you want to spot all branch points in the tree.